### PR TITLE
Goutte calls CookieJar::getValues instead of CookieJar::allValues

### DIFF
--- a/src/Goutte/Client.php
+++ b/src/Goutte/Client.php
@@ -66,7 +66,7 @@ class Client extends BaseClient
             $client->setParameterGet($request->getParameters());
         }
 
-        foreach ($this->getCookieJar()->getValues($request->getUri()) as $name => $value) {
+        foreach ($this->getCookieJar()->allValues($request->getUri()) as $name => $value) {
             $client->setCookie($name, $value);
         }
 


### PR DESCRIPTION
Just fixed this bug after https://github.com/symfony/symfony/commit/ff3c66753fc5e89b730290bcdc0d3e170c5abc51#L2R107
