### PR TITLE
Fixed method of setting headers

### DIFF
--- a/src/Goutte/Client.php
+++ b/src/Goutte/Client.php
@@ -81,7 +81,7 @@ class Client extends BaseClient
         }
 
         foreach ($this->headers as $name => $value) {
-            $client->setHeaders($name, $value);
+            $client->setHeaders(array($name => $value));
         }
 
         if ($this->auth !== null) {


### PR DESCRIPTION
Hello,

Using code below with current master branch causes 'Zend\Http\Exception\InvalidArgumentException' being thrown. That's because Zend's Zend\Http\Client's setHeaders() method expects it's parameter to be Array or instance of Zend\Http\Headers.

Fix included.

Regards, 
JB

//the "code below"
require_once **DIR**.'/autoload.php';

use Goutte\Client;

$client = new Client();

$client->setHeader('X-FOO', 'Bar');

$crawler = $client->request('GET', 'http://www.symfony-project.org/');
