### PR TITLE
Fixes problem with multi-dimensional files array

### DIFF
--- a/src/Goutte/Client.php
+++ b/src/Goutte/Client.php
@@ -101,7 +101,8 @@ class Client extends BaseClient
     /**
      * Goes recursively through the files array and adds uploads to the ZendClient
      */
-    protected function addFileUploadsRecursively(ZendClient $client, array $files, $arrayName = '') {
+    protected function addFileUploadsRecursively(ZendClient $client, array $files, $arrayName = '')
+    {
         foreach ($files as $name => $info) {
             if (!empty($arrayName)) {
                 $name = $arrayName . '[' . $name . ']';


### PR DESCRIPTION
Symfony\Component\BrowserKit\Request->getFiles() can return a multi-dimensional array with nested uploads for example given an input-element which has an array as name:

```
<input type="file" name="baa[foo]" />
```

would result in an array like:

```
array(1) {
  ["baa"]=>
  array(1) {
    ["foo"]=>
    array(5) {
      ["name"]=>
      string(13) "some_file.txt"
      ["type"]=>
      string(0) ""
      ["tmp_name"]=>
      string(17) "/tmp/uploadRYvrqA"
      ["error"]=>
      string(1) "0"
      ["size"]=>
      string(2) "16"
    }
  }
}
```

So it needs to recursivly go through the array and add the files.

Related to https://github.com/Behat/Mink/issues/106
