### PR TITLE
Don't encode cookies inside Goutte, as it breaks them

### DIFF
--- a/src/Goutte/Client.php
+++ b/src/Goutte/Client.php
@@ -113,6 +113,6 @@ class Client extends BaseClient
 
     protected function createZendClient()
     {
-        return new ZendClient();
+        return new ZendClient(null, array('encodecookies' => false));
     }
 }


### PR DESCRIPTION
New default cookie encoding mechanism breaks cookies inside Goutte, Mink and other tools. I've simply turned it off, as it's not needed in Goutte - BrowserKit has it's own cookie escaping mechanism.
