### PR TITLE
set raw cookies to Guzzle for proper evaluation

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -89,7 +89,7 @@ class Client extends BaseClient
             );
         }
 
-        foreach ($this->getCookieJar()->allValues($request->getUri()) as $name => $value) {
+        foreach ($this->getCookieJar()->allRawValues($request->getUri()) as $name => $value) {
             $guzzleRequest->addCookie($name, $value);
         }
 


### PR DESCRIPTION
Seems that Guzzle doesn't evaluate properly clean cookie values
when there's some cookie with `some:value;`, setting clean value
to Guzzle makes him to lose `;`. Using `allRawValues()` instead
fixed issue.
