### PR TITLE
create request with body only for non-(GET|HEAD) requests

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -84,7 +84,7 @@ class Client extends BaseClient
             strtoupper($request->getMethod()),
             $request->getUri(),
             array_merge($this->headers, $headers),
-            $request->getParameters()
+            in_array($request->getMethod(), array('GET','HEAD')) ? null : $request->getParameters()
         );
 
         if ($this->auth !== null) {


### PR DESCRIPTION
Before this commit, Goutte was sending request parameters on any
type of request, including GET-forms. This caused exceptions in
Guzzle as it doesn't support bodies for GET requests. After this
commit, body will be added to request **only** for GET|HEAD
requests
