### PR TITLE
Fixing unit test for latest update to how Guzzle handles POST uploads

### DIFF
--- a/Goutte/Tests/ClientTest.php
+++ b/Goutte/Tests/ClientTest.php
@@ -105,7 +105,12 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $request = $this->historyPlugin->getLastRequest();
 
         $this->assertEquals(array(
-            'test' => __FILE__
+            'test' => array(
+                array(
+                    'file' => __FILE__,
+                    'type' => 'text/x-php'
+                )
+            )
         ), $request->getPostFiles());
     }
 


### PR DESCRIPTION
I added much better support for POST uploads in 2.6.3.  This change fixes a unit test that was expecting the old format of how POST files are internally stored in an EntityEnclosingRequest.
