### PR TITLE
Use CURLAUTH_BASIC instead of GuzzleRequestInterface::AUTH_BASIC

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -59,7 +59,7 @@ class Client extends BaseClient
         return $this;
     }
 
-    public function setAuth($user, $password = '', $type = GuzzleRequestInterface::AUTH_BASIC)
+    public function setAuth($user, $password = '', $type = CURLAUTH_BASIC)
     {
         $this->auth = array(
             'user' => $user,


### PR DESCRIPTION
This is what $guzzleRequest->setAuth() expects: https://github.com/guzzle/guzzle/blob/master/src/Guzzle/Http/Message/Request.php#L493
