### PR TITLE
fix problems with autoload automatically generated namespace spec contai...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     },
     "autoload": {
         "psr-0": { "Goutte": "." }
+        "target-dir": "."
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
...ning .../src by default so that it can look on .

problems:

Fatal error: Class 'Goutte\Client' not found in /home/cordoval/sites-2/knpbundles/src/Knp/Bundle/KnpBundlesBundle/Finder/CommonFinder.php on line 32

because it is trying to look for 

```
'Goutte' => $vendorDir . '/fabpot/goutte/src/',
```
