### PR TITLE
Fix Compiler.php packages path

### DIFF
--- a/Goutte/Compiler.php
+++ b/Goutte/Compiler.php
@@ -83,7 +83,7 @@ class Compiler
         $dirs = array(
             'vendor/composer',
             'vendor/symfony',
-            'vendor/guzzle/guzzle/src/Guzzle'
+            'vendor/guzzle'
         );
 
         $iterator = Finder::create()->files()->name('*.php')->in($dirs);


### PR DESCRIPTION
I tried

```
git://github.com/fabpot/Goutte.git
wget http://getcomposer.org/composer.phar
php composer.phar install
php compile
```

```
$ php compile
PHP Fatal error:  Uncaught exception 'InvalidArgumentException' with message 'The "vendor/guzzle/guzzle/src/Guzzle" directory does not exist.' in MYPATH/Goutte/vendor/symfony/finder/Symfony/Component/Finder/Finder.php:498
```
