### PR TITLE
Invalid files attached for non-required file fields

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -147,10 +147,9 @@ class Client extends BaseClient
             if (!empty($arrayName)) {
                 $name = $arrayName . '[' . $name . ']';
             }
-
-            if (isset($info['tmp_name']) && '' !== $info['tmp_name']) {
+            if (is_array($info) && isset($info['tmp_name']) && '' !== $info['tmp_name']) {
                 $request->addPostFile($name, $info['tmp_name']);
-            } elseif (is_array($info) && !empty($info['name'])) {
+            } elseif (is_array($info)) {
                 $this->addPostFiles($request, $info, $name);
             }
         }


### PR DESCRIPTION
Since the change to support multi-dimensional files (https://github.com/fabpot/Goutte/commit/b207ffcbde82dcfa7e84737942636f4d56a1d665) went in, I've been seeing invalid files attached to POST submissions if the file field is left empty.

Sample html document available (https://gist.github.com/3645288 see line 250 or so).

For this example, the `$files` array that gets passed into the `addPostFiles()` method consists of the following:

```
array(1) {
  'field_project_images_0' =>
  array(5) {
    'name' =>
    string(0) ""
    'type' =>
    string(0) ""
    'tmp_name' =>
    string(0) ""
    'error' =>
    string(1) "4"
    'size' =>
    string(1) "0"
  }
}
```

This change seems to fix the issue, since it only sets the file if a name exists.
