### PR TITLE
Enforce no follow redirects on all clients doRequest.

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -116,6 +116,7 @@ class Client extends BaseClient
             $this->addPostFiles($guzzleRequest, $request->getFiles());
         }
 
+        $guzzleRequest->getParams()->set('redirect.disable', true);
         $curlOptions = $guzzleRequest->getCurlOptions();
 
         if (!$curlOptions->get(CURLOPT_TIMEOUT)) {


### PR DESCRIPTION
This one was pretty tricky, but it looks like the default client initialization configs (specifically to disable redirects) are not always used. This explicitly sets no redirect to allow the scraper to follow redirects; which is necessary for tasks like resetting the base url on a redirect.
