### PR TITLE
Add syntaxic sugar to call regular HTTP methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 phpunit.xml
 vendor
-
+nbproject

--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -69,6 +69,74 @@ class Client extends BaseClient
 
         return $this;
     }
+    
+    /**
+     * Calls a URI using GET method.
+     *
+     * @param string  $uri           The URI to fetch
+     * @param array   $parameters    The Request parameters
+     * @param array   $files         The files
+     * @param array   $server        The server parameters (HTTP headers are referenced with a HTTP_ prefix as PHP does)
+     * @param string  $content       The raw body data
+     * @param Boolean $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
+     *
+     * @return \Symfony\Component\DomCrawler\Crawler
+     */
+    public function get($uri, array $parameters = array(), array $files = array(), array $server = array(), $content = null, $changeHistory = true)
+    {
+        return $this->request("GET", $uri, $parameters, $files, $server, $content, $changeHistory);
+    }
+    
+    /**
+     * Calls a URI using POST method.
+     *
+     * @param string  $uri           The URI to fetch
+     * @param array   $parameters    The Request parameters
+     * @param array   $files         The files
+     * @param array   $server        The server parameters (HTTP headers are referenced with a HTTP_ prefix as PHP does)
+     * @param string  $content       The raw body data
+     * @param Boolean $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
+     *
+     * @return \Symfony\Component\DomCrawler\Crawler
+     */
+    public function post($uri, array $parameters = array(), array $files = array(), array $server = array(), $content = null, $changeHistory = true)
+    {
+        return $this->request("POST", $uri, $parameters, $files, $server, $content, $changeHistory);
+    }
+    
+    /**
+     * Calls a URI using PUT method.
+     *
+     * @param string  $uri           The URI to fetch
+     * @param array   $parameters    The Request parameters
+     * @param array   $files         The files
+     * @param array   $server        The server parameters (HTTP headers are referenced with a HTTP_ prefix as PHP does)
+     * @param string  $content       The raw body data
+     * @param Boolean $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
+     *
+     * @return \Symfony\Component\DomCrawler\Crawler
+     */
+    public function put($uri, array $parameters = array(), array $files = array(), array $server = array(), $content = null, $changeHistory = true)
+    {
+        return $this->request("PUT", $uri, $parameters, $files, $server, $content, $changeHistory);
+    }
+    
+    /**
+     * Calls a URI using DELETE method.
+     *
+     * @param string  $uri           The URI to fetch
+     * @param array   $parameters    The Request parameters
+     * @param array   $files         The files
+     * @param array   $server        The server parameters (HTTP headers are referenced with a HTTP_ prefix as PHP does)
+     * @param string  $content       The raw body data
+     * @param Boolean $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
+     *
+     * @return \Symfony\Component\DomCrawler\Crawler
+     */
+    public function delete($uri, array $parameters = array(), array $files = array(), array $server = array(), $content = null, $changeHistory = true)
+    {
+        return $this->request("DELETE", $uri, $parameters, $files, $server, $content, $changeHistory);
+    }
 
     protected function doRequest($request)
     {

--- a/Goutte/Tests/ClientTest.php
+++ b/Goutte/Tests/ClientTest.php
@@ -244,4 +244,49 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         // Ensure that two requests were sent
         $this->assertEquals(2, count($this->historyPlugin));
     }
+    
+    public function getMockGoutteClientToTestSugarCalls($method)
+    {
+        $client = $this->getMockBuilder("Goutte\Client")
+                ->setMethods(array("request"))
+                ->disableOriginalConstructor()
+                ->getMock();
+        $client->expects($this->once())
+               ->method("request")
+               ->with(
+                       $this->equalTo($method),
+                       $this->equalTo("uri"),
+                       $this->equalTo(array("parameters")),
+                       $this->equalTo(array("files")),
+                       $this->equalTo(array("server")),
+                       $this->equalTo("content"),
+                       $this->equalTo("changeHistory"))
+               ->will($this->returnValue("fakeCrawler"));
+        
+        return $client;
+    }
+    
+    public function testCallRequestUsingGetSugar()
+    {
+        $client = $this->getMockGoutteClientToTestSugarCalls("GET");
+        $this->assertEquals("fakeCrawler", $client->get("uri", array("parameters"), array("files"), array("server"), "content", "changeHistory"));
+    }
+    
+    public function testCallRequestUsingPostSugar()
+    {
+        $client = $this->getMockGoutteClientToTestSugarCalls("POST");
+        $this->assertEquals("fakeCrawler", $client->post("uri", array("parameters"), array("files"), array("server"), "content", "changeHistory"));
+    }
+    
+    public function testCallRequestUsingPutSugar()
+    {
+        $client = $this->getMockGoutteClientToTestSugarCalls("PUT");
+        $this->assertEquals("fakeCrawler", $client->put("uri", array("parameters"), array("files"), array("server"), "content", "changeHistory"));
+    }
+    
+    public function testCallRequestUsingDeleteSugar()
+    {
+        $client = $this->getMockGoutteClientToTestSugarCalls("DELETE");
+        $this->assertEquals("fakeCrawler", $client->delete("uri", array("parameters"), array("files"), array("server"), "content", "changeHistory"));
+    }
 }


### PR DESCRIPTION
Add "get", "post", "put" and "delete" methods to client object so that users can call them instead of having to call request("GET", ...), request("POST", ...), ...
Tests have been updated as well
