### PR TITLE
FIX: ability to set custom CURLOPT_TIMEOUT

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -119,7 +119,7 @@ class Client extends BaseClient
         $guzzleRequest->getParams()->set('redirect.disable', true);
         $curlOptions = $guzzleRequest->getCurlOptions();
 
-        if (!$curlOptions->get(CURLOPT_TIMEOUT)) {
+        if (!$curlOptions->hasKey(CURLOPT_TIMEOUT)) {
             $curlOptions->set(CURLOPT_TIMEOUT, 30);
         }
 


### PR DESCRIPTION
- does not work when CURLOPT_TIMEOUT is 0, so that timeout is disabled
