### PR TITLE
Bump dependencies constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
     "require": {
         "php": ">=5.3.0",
         "ext-curl": "*",
-        "symfony/browser-kit": ">=2.1, <2.3-dev",
-        "symfony/css-selector": ">=2.1, <2.3-dev",
-        "symfony/dom-crawler": ">=2.1, <2.3-dev",
-        "symfony/finder": ">=2.1, <2.3-dev",
-        "symfony/process": ">=2.1, <2.3-dev",
+        "symfony/browser-kit": ">=2.1, <2.4-dev",
+        "symfony/css-selector": ">=2.1, <2.4-dev",
+        "symfony/dom-crawler": ">=2.1, <2.4-dev",
+        "symfony/finder": ">=2.1, <2.4-dev",
+        "symfony/process": ">=2.1, <2.4-dev",
         "guzzle/guzzle": "3.0.*"
     },
     "autoload": {


### PR DESCRIPTION
Also, could you tag `goutte` version so we could remove `minimum-stability` from our `composer.json`? Thanks :)
