### PR TITLE
Added ability to remove request header

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -59,6 +59,11 @@ class Client extends BaseClient
         return $this;
     }
 
+    public function removeHeader($name)
+    {
+        unset($this->headers[$name]);
+    }
+
     public function setAuth($user, $password = '', $type = CURLAUTH_BASIC)
     {
         $this->auth = array(


### PR DESCRIPTION
Use case: If you are in a mink behat context and you specify a step definition where a request header gets set. Afterwards you want to assert what happens without the header so you need a way to unset the header within the next step definition.
