### PR TITLE
400 Bad Request - Invalid Headers

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -74,7 +74,7 @@ class Client extends BaseClient
     {
         $headers = array();
         foreach ($request->getServer() as $key => $val) {
-            $key = ucfirst(strtolower(str_replace(array('_', 'HTTP-'), array('-', ''), $key)));
+            $key = implode('-', array_map('ucfirst', explode('-', strtolower(str_replace(array('_', 'HTTP-'), array('-', ''), $key)))));
             if (!isset($headers[$key])) {
                 $headers[$key] = $val;
             }


### PR DESCRIPTION
There's a problem with Goutte HTTP header naming when it uppercase only the first character of the header name, for instance, User-agent. Guzzle sets its own user agent header as "User-Agent" with both initial letters uppercased. When a request is made, instead of one header overwriting the other, both are snet to the web server. IIS, for instance, rejects the request: 400 Bad Request - Invalid Headers.

This one line fix makes the first character of all parts of the header name uppercased.
