### PR TITLE
Use toArray() rather than deprecated raw()

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -172,7 +172,7 @@ class Client extends BaseClient
         $headers = $response->getHeaders()->getAll();
         $headers = array_map(function ($header) {
             if ($header instanceof GuzzleHeader) {
-                return $header->raw();
+                return $header->toArray();
             }
 
             return $header;


### PR DESCRIPTION
Sorry for the mess around, there's no mention of it being deprecated in the API docs, but it does say so in the code.
