### PR TITLE
Add composer installation documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,20 +11,40 @@ Requirements
 
 Goutte works with PHP 5.3.3 or later.
 
-Installation
-------------
+Installing via Composer
+-----------------------
+
+The recommended way to install Goutte is through `Composer`_.
+
+.. code-block:: bash
+
+    # Install Composer
+    curl -sS https://getcomposer.org/installer | php
+
+    # Add Goutte as a dependency
+    php composer.phar require fabpot/goutte:~1.0
+
+After installing, you need to require Composer's autoloader:
+
+.. code-block:: php
+
+    require 'vendor/autoload.php';
+
+Installing via Phar
+-------------------
 
 Installing Goutte is as easy as it can get. Download the `Goutte.phar`_ file
 and you're done!
 
-Usage
------
 
 Require the Goutte phar file to use Goutte in a script:
 
 .. code-block:: php
 
     require_once '/path/to/goutte.phar';
+
+Usage
+-----
 
 Create a Goutte Client instance (which extends
 ``Symfony\Component\BrowserKit\Client``):
@@ -95,5 +115,6 @@ License
 
 Goutte is licensed under the MIT license.
 
+.. _`Composer`: http://getcomposer.org
 .. _`Goutte.phar`: http://get.sensiolabs.org/goutte.phar
 .. _`Guzzle`:      http://docs.guzzlephp.org


### PR DESCRIPTION
This adds information to the documentation regarding installing Goutte via composer.
