### PR TITLE
use HeaderCollection::toArray to fix lowercased header names

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -17,7 +17,6 @@ use Symfony\Component\BrowserKit\Response;
 use Guzzle\Http\Exception\CurlException;
 use Guzzle\Http\Exception\BadResponseException;
 use Guzzle\Http\Message\Response as GuzzleResponse;
-use Guzzle\Http\Message\Header as GuzzleHeader;
 use Guzzle\Http\ClientInterface as GuzzleClientInterface;
 use Guzzle\Http\Client as GuzzleClient;
 use Guzzle\Http\Message\EntityEnclosingRequestInterface;


### PR DESCRIPTION
When creating a Response in Goutte client from a GuzzleResponse, headers names are lowercased.
(location, content-type instead of Location, Content-type).

(see https://github.com/guzzle/guzzle/blob/master/src/Guzzle/Http/Message/Header/HeaderCollection.php#L44)

Rather than use `getAll` method of `HeaderCollection`, we better use [`toArray`](https://github.com/guzzle/guzzle/blob/master/src/Guzzle/Http/Message/Header/HeaderCollection.php#L99).
