### PR TITLE
Cleaned the composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,9 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "ext-curl": "*",
         "symfony/browser-kit": "~2.1",
         "symfony/css-selector": "~2.1",
         "symfony/dom-crawler": "~2.1",
-        "symfony/finder": "~2.1",
-        "symfony/process": "~2.1",
         "guzzlehttp/guzzle": "4.*"
     },
     "autoload": {


### PR DESCRIPTION
The Process and Finder components are left-overs of the custom Phar building (and they should have been dev requirements at this time btw).
The curl requirement is a left-over of Goutte 1.x. It is not a requirement of 2.x anymore.
