### PR TITLE
Fixes for #146

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -80,7 +80,12 @@ class Client extends BaseClient
         $headers = array();
         foreach ($request->getServer() as $key => $val) {
             $key = implode('-', array_map('ucfirst', explode('-', strtolower(str_replace(array('_', 'HTTP-'), array('-', ''), $key)))));
-            if (!isset($headers[$key]) && !empty($val)) {
+            $contentHeaders = array('Content-length' => true, 'Content-md5' => true, 'Content-type' => true);
+            if (0 === strpos($key, 'Http-')) {
+                $headers[substr($key, 5)] = $val;
+            }
+            // CONTENT_* are not prefixed with HTTP_
+            elseif (isset($contentHeaders[$key])) {
                 $headers[$key] = $val;
             }
         }

--- a/Goutte/Tests/ClientTest.php
+++ b/Goutte/Tests/ClientTest.php
@@ -278,6 +278,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client = new Client();
         $client->setClient($guzzle);
         $crawler = $client->request('GET', 'https://www.example.com/');
+        $this->assertEquals('https', $this->history->getLastRequest()->getScheme());
         $this->assertEquals('Test', $crawler->filter('p')->text());
     }
 }


### PR DESCRIPTION
Demonstrates bug in #146
Basically Guzzle 4.0 doesn't support boolean header values.
So for special case of Https, we convert that to 'on'.
Not sure if anything is needed at all.
