### PR TITLE
Added timeout configuration

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -32,6 +32,7 @@ class Client extends BaseClient
 
     private $headers = array();
     private $auth = null;
+    private $timeout = null;
 
     public function setClient(GuzzleClientInterface $client)
     {
@@ -75,6 +76,20 @@ class Client extends BaseClient
         return $this;
     }
 
+    public function setTimeout($seconds)
+    {
+        $this->timeout = $seconds;
+
+        return $this;
+    }
+
+    public function resetTimeout()
+    {
+        $this->timeout = null;
+
+        return $this;
+    }
+
     protected function doRequest($request)
     {
         $headers = array();
@@ -105,7 +120,7 @@ class Client extends BaseClient
             'body' => $body,
             'cookies' => $this->getCookieJar()->allRawValues($request->getUri()),
             'allow_redirects' => false,
-            'timeout' => 30,
+            'timeout' => (!is_null($this->timeout) && is_int($this->timeout)) ? $this->timeout : 30,
         );
 
         if (!empty($headers)) {


### PR DESCRIPTION
Hi.

When we use scrapper to get some files on multiples pages, the time to access complete request can be important.
We usualy use 300s as a good timeout for the operations I need to do.

I think we should add the possibility to configure the timeout of the request.
