### PR TITLE
Fix for Content-Disposition filename

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -149,7 +149,7 @@ class Client extends BaseClient
             if (is_array($info)) {
                 if (isset($info['tmp_name'])) {
                     if ('' !== $info['tmp_name']) {
-                        $request->getBody()->addFile(new PostFile($name, fopen($info['tmp_name'], 'r')));
+                        $request->getBody()->addFile(new PostFile($name, fopen($info['tmp_name'], 'r'), isset($info['name']) ? $info['name'] : null));
                     } else {
                         continue;
                     }

--- a/Goutte/Tests/ClientTest.php
+++ b/Goutte/Tests/ClientTest.php
@@ -130,9 +130,9 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $request = $this->history->getLastRequest();
 
         $files = $request->getBody()->getFiles();
-        $this->assertFile(reset($files), 'test', __FILE__, array(
-          'Content-Type' => 'text/x-php',
-          'Content-Disposition' => 'form-data; filename="ClientTest.php"; name="test"',
+        $this->assertFile(reset($files), 'test', 'test.txt', array(
+          'Content-Type' => 'text/plain',
+          'Content-Disposition' => 'form-data; filename="test.txt"; name="test"',
         ));
     }
 
@@ -171,9 +171,9 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $crawler = $client->request('POST', 'http://www.example.com/', array(), $files);
         $request = $this->history->getLastRequest();
         $files = $request->getBody()->getFiles();
-        $this->assertFile(reset($files), 'form[test]', __FILE__, array(
-            'Content-Type' => 'text/x-php',
-            'Content-Disposition' => 'form-data; filename="ClientTest.php"; name="form[test]"',
+        $this->assertFile(reset($files), 'form[test]', 'test.txt', array(
+            'Content-Type' => 'text/plain',
+            'Content-Disposition' => 'form-data; filename="test.txt"; name="form[test]"',
         ));
     }
 


### PR DESCRIPTION
Whilst working on making Drupal work with Mink (Goutte 2.0) we've hit issue with Content-Disposition file-names, basically all uploaded files end up with the temporary name.
