### PR TITLE
Updated README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,8 +100,7 @@ Technical Information
 
 Goutte is a thin wrapper around the following fine PHP libraries:
 
-* Symfony Components: BrowserKit, ClassLoader, CssSelector, DomCrawler, Finder,
-  and Process;
+* Symfony Components: BrowserKit, CssSelector and DomCrawler;
 
 *  `Guzzle`_ HTTP Component.
 


### PR DESCRIPTION
Removed unused components from README: ClassLoader, Finder and Process.

see https://github.com/fabpot/Goutte/pull/143
