### PR TITLE
Fixes #179

### DIFF
--- a/Goutte/Tests/ClientTest.php
+++ b/Goutte/Tests/ClientTest.php
@@ -280,7 +280,16 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals($postFile->getName(), $fieldName);
         $this->assertEquals($postFile->getFilename(), $fileName);
-        $this->assertEquals($postFile->getHeaders(), $headers);
+
+        $postFileHeaders = $postFile->getHeaders();
+        
+        // Note: Sort 'Content-Disposition' values before comparing, because the order changed in Guzzle 4.2.2
+        $postFileHeaders['Content-Disposition'] = explode('; ', $postFileHeaders['Content-Disposition']);
+        sort($postFileHeaders['Content-Disposition']);
+        $headers['Content-Disposition'] = explode('; ', $headers['Content-Disposition']);
+        sort($headers['Content-Disposition']);
+
+        $this->assertEquals($postFileHeaders, $headers);
     }
 
     public function testHttps()


### PR DESCRIPTION
Fixes #179 so that the tests comparing "Content-Disposition" header values work with all versions of Guzzle.
