### PR TITLE
Enable file upload by passing file content data

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -153,6 +153,8 @@ class Client extends BaseClient
                     } else {
                         continue;
                     }
+                } elseif (isset($info['content'])) {
+                    $request->getBody()->addFile(new PostFile($name, $info['content'], isset($info['name']) ? $info['name'] : null));
                 } else {
                     $this->addPostFiles($request, $info, $name);
                 }


### PR DESCRIPTION
When submitting a form, currently Goutte Client can upload a file only using an existing file path, so I added the use of a 'content' element for file info array in the request. In this way the Client can upload a file by passing file content as a string, a stream resource or an object.
