### PR TITLE
Loosen README version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Goutte depends on PHP 5.4+ and Guzzle 4+.
 
 .. tip::
 
-    If you need support for PHP 5.3 or Guzzle 3, use Goutte 1.0.6.
+    If you need support for PHP 5.3 or Guzzle 3, use Goutte 1.x.
 
 Installation
 ------------


### PR DESCRIPTION
1.0.7 was released a while ago, to save having to update this it should just refer to the branch.