### PR TITLE
Fix the handling of cookie for URLs with a custom port

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -17,6 +17,7 @@ use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\BrowserKit\Client as BaseClient;
+use Symfony\Component\BrowserKit\Request;
 use Symfony\Component\BrowserKit\Response;
 
 /**
@@ -75,6 +76,11 @@ class Client extends BaseClient
         return $this;
     }
 
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     */
     protected function doRequest($request)
     {
         $headers = array();
@@ -92,7 +98,7 @@ class Client extends BaseClient
 
         $cookies = CookieJar::fromArray(
             $this->getCookieJar()->allRawValues($request->getUri()),
-            $request->getServer()['HTTP_HOST']
+            parse_url($request->getUri(), PHP_URL_HOST)
         );
 
         $requestOptions = array(

--- a/Goutte/Tests/ClientTest.php
+++ b/Goutte/Tests/ClientTest.php
@@ -114,6 +114,17 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('test=123', $request->getHeaderLine('Cookie'));
     }
 
+    public function testUsesCookiesWithCustomPort()
+    {
+        $guzzle = $this->getGuzzle();
+        $client = new Client();
+        $client->setClient($guzzle);
+        $client->getCookieJar()->set(new Cookie('test', '123'));
+        $client->request('GET', 'http://www.example.com:8000/');
+        $request = end($this->history)['request'];
+        $this->assertEquals('test=123', $request->getHeaderLine('Cookie'));
+    }
+
     public function testUsesPostFiles()
     {
         $guzzle = $this->getGuzzle();


### PR DESCRIPTION
In recent Symfony version, BrowserKit includes the port in ``HTTP_HOST`` to match the specification of the header.
But the Guzzle CookieJar does not want this host here, it wants the domain only. Otherwise the cookies won't match.

closes #232