### PR TITLE
Proposal: Allow setting of the User-Agent like Guzzle does

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -95,6 +95,24 @@ class Client extends BaseClient
                 $headers[$key] = $val;
             }
         }
+        
+        $config = $this->getClient()->getConfig();
+        if (! empty($config['headers'])) {
+            foreach($config['headers'] as $key => $value) {
+                $this->removeHeader($key);
+                $key = strtolower(str_replace('_', '-', $key));
+                $this->headers[$key] = $value;
+            }
+        }
+        
+        $params = $request->getParameters();
+        if (! empty($params['headers'])) {
+            foreach($params['headers'] as $key => $value) {
+                $this->removeHeader($key);
+                $key = strtolower(str_replace('_', '-', $key));
+                $this->headers[$key] = $value;
+            }
+        }
 
         $cookies = CookieJar::fromArray(
             $this->getCookieJar()->allRawValues($request->getUri()),

--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -95,7 +95,7 @@ class Client extends BaseClient
                 $headers[$key] = $val;
             }
         }
-        
+    
         $config = $this->getClient()->getConfig();
         if (!empty($config['headers'])) {
             foreach($config['headers'] as $key => $value) {
@@ -104,7 +104,7 @@ class Client extends BaseClient
                 $this->headers[$key] = $value;
             }
         }
-        
+    
         $params = $request->getParameters();
         if (!empty($params['headers'])) {
             foreach($params['headers'] as $key => $value) {

--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -97,7 +97,7 @@ class Client extends BaseClient
         }
         
         $config = $this->getClient()->getConfig();
-        if (! empty($config['headers'])) {
+        if (!empty($config['headers'])) {
             foreach($config['headers'] as $key => $value) {
                 $this->removeHeader($key);
                 $key = strtolower(str_replace('_', '-', $key));
@@ -106,7 +106,7 @@ class Client extends BaseClient
         }
         
         $params = $request->getParameters();
-        if (! empty($params['headers'])) {
+        if (!empty($params['headers'])) {
             foreach($params['headers'] as $key => $value) {
                 $this->removeHeader($key);
                 $key = strtolower(str_replace('_', '-', $key));

--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -95,7 +95,7 @@ class Client extends BaseClient
                 $headers[$key] = $val;
             }
         }
-    
+
         $config = $this->getClient()->getConfig();
         if (!empty($config['headers'])) {
             foreach($config['headers'] as $key => $value) {
@@ -104,7 +104,7 @@ class Client extends BaseClient
                 $this->headers[$key] = $value;
             }
         }
-    
+
         $params = $request->getParameters();
         if (!empty($params['headers'])) {
             foreach($params['headers'] as $key => $value) {

--- a/Goutte/Tests/ClientTest.php
+++ b/Goutte/Tests/ClientTest.php
@@ -77,7 +77,34 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client->setClient($guzzle);
         $client->setHeader('User-Agent', 'foo');
         $client->request('GET', 'http://www.example.com/');
-        $this->assertEquals('Symfony2 BrowserKit, foo', end($this->history)['request']->getHeaderLine('User-Agent'));
+        $this->assertEquals('foo', end($this->history)['request']->getHeaderLine('User-Agent'));
+    }
+
+    public function testCustomUserAgentUsingConfig()
+    {
+        $options = [
+            'headers' => [
+                'User-Agent' => 'foo'    
+            ]
+        ]
+        $guzzle = $this->getGuzzle();
+        $client = new Client();
+        $client->setClient($guzzle);
+        $client->request('GET', 'http://www.example.com/');
+        $this->assertEquals('foo', end($this->history)['request']->getHeaderLine('User-Agent'));
+    }
+
+    public function testCustomUserAgentUsingParams()
+    {
+        $guzzle = $this->getGuzzle();
+        $client = new Client();
+        $client->setClient($guzzle);
+        $client->request('GET', 'http://www.example.com/', [
+            'headers' => [
+                'User-Agent' => 'foo'    
+            ]    
+        ]);
+        $this->assertEquals('foo', end($this->history)['request']->getHeaderLine('User-Agent'));
     }
 
     public function testUsesAuth()

--- a/Goutte/Tests/ClientTest.php
+++ b/Goutte/Tests/ClientTest.php
@@ -86,8 +86,9 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             'headers' => [
                 'User-Agent' => 'foo',
             ],
-        ]
+        ];
         $guzzle = $this->getGuzzle();
+        $guzzle->setClient($options);
         $client = new Client();
         $client->setClient($guzzle);
         $client->request('GET', 'http://www.example.com/');

--- a/Goutte/Tests/ClientTest.php
+++ b/Goutte/Tests/ClientTest.php
@@ -84,8 +84,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $options = [
             'headers' => [
-                'User-Agent' => 'foo'    
-            ]
+                'User-Agent' => 'foo',
+            ],
         ]
         $guzzle = $this->getGuzzle();
         $client = new Client();
@@ -101,8 +101,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client->setClient($guzzle);
         $client->request('GET', 'http://www.example.com/', [
             'headers' => [
-                'User-Agent' => 'foo'    
-            ]    
+                'User-Agent' => 'foo',
+            ],
         ]);
         $this->assertEquals('foo', end($this->history)['request']->getHeaderLine('User-Agent'));
     }


### PR DESCRIPTION
Proposal: Allow setting of the User-Agent and other Headers like Guzzle does.

Maybe the Goutte docs are lacking or I didn't look hard enough, but until I started digging around in the source I had a hard time trying to set the HTTP_USER_AGENT.

First I looked at Guzzle's documentation https://guzzle.readthedocs.org/en/latest/ and it seems that you can set the user-agent both when creating the $client and also at the $client->request() stage.

Guzzle - Creating the client.
~~~
$client = new Client([
    // Base URI is used with relative requests
    'base_uri' => 'http://httpbin.org',
    // You can set any number of default request options.
    'timeout'  => 2.0,
    'headers' => [
        'user-agent' => $ua
    ]
]);
~~~

Guzzle - or on the request:
~~~
// Set various headers on a request
$client->request('GET', '/get', [
    'headers' => [
        'User-Agent' => 'testing/1.0',
        'Accept'     => 'application/json'
    ]
]);
~~~

Oddly, Goutte seems to work the same way for everything but the user-agent!

Instead you need to do `$client->setHeader('user-agent', $ua);`, which I only figured out by reading the source code.

So here's a proposal to allow you to set the user-agent (and other headers) just like Guzzle.

The way I have implemented it, is that anything set at the request stage will override anything set when initially creating the client.

It can be done better no doubt if you want to take the time :)

Also it might be a bit confusing how you get the options to work, so here's how I did it...
~~~
$options = [
    'base_uri' => $uri,
    'timeout' => 12.0,
    'connect_timeout' => 6.0,
    'proxy' => [
        'http' => $proxy,
        'https' => $proxy
    ],
    'allow_redirects' => false,
    'headers' => [ // user-agent doesn't currently work with Goutte
        'User-Agent' => $ua,
        'Accept' => $accept,
        'Accept-Encoding' => 'gzip, deflate',
        'Connection' => 'keep-alive',
        'Accept-Language' => 'en-GB,en;q=0.5'
    ],
    'verify' => false,
];

$client = new Client(); // use Goutte\Client;

$guzzleClient = new GuzzleClient($options); // use GuzzleHttp\Client as GuzzleClient;

$client->setClient($guzzleClient);

$response = $client->request('GET', $uri);
~~~