### PR TITLE
Normalize header case

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -52,14 +52,14 @@ class Client extends BaseClient
 
     public function setHeader($name, $value)
     {
-        $this->headers[$name] = $value;
+        $this->headers[strtolower($name)] = $value;
 
         return $this;
     }
 
     public function removeHeader($name)
     {
-        unset($this->headers[$name]);
+        unset($this->headers[strtolower($name)]);
     }
 
     public function setAuth($user, $password = '', $type = 'basic')

--- a/Goutte/Tests/ClientTest.php
+++ b/Goutte/Tests/ClientTest.php
@@ -77,7 +77,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client->setClient($guzzle);
         $client->setHeader('User-Agent', 'foo');
         $client->request('GET', 'http://www.example.com/');
-        $this->assertEquals('Symfony2 BrowserKit, foo', end($this->history)['request']->getHeaderLine('User-Agent'));
+        $this->assertEquals('foo', end($this->history)['request']->getHeaderLine('User-Agent'));
     }
 
     public function testUsesAuth()


### PR DESCRIPTION
This makes sure that the case of headers are always normalised, to avoid unexpected behaviour (I thought Guzzle would have dealt with this, but apparently not). The move to Guzzle 6 appears to have changed a test case to the broken result.

Fixes #241.
