### PR TITLE
Add support for other types of CookieJar, eg. FileCookieJar and SessionCookieJar

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -14,6 +14,7 @@ namespace Goutte;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\ClientInterface as GuzzleClientInterface;
 use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Cookie\SetCookie;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\BrowserKit\Client as BaseClient;
@@ -33,6 +34,7 @@ class Client extends BaseClient
 
     private $headers = array();
     private $auth = null;
+    private $guzzleCookieJar = null;
 
     public function setClient(GuzzleClientInterface $client)
     {
@@ -76,6 +78,19 @@ class Client extends BaseClient
         return $this;
     }
 
+    public function getGuzzleCookieJar()
+    {
+        if (empty($this->guzzleCookieJar)) {
+            $this->guzzleCookieJar = new CookieJar();
+        }
+        return $this->guzzleCookieJar;
+    }
+
+    public function setGuzzleCookieJar($guzzleCookieJar)
+    {
+        $this->guzzleCookieJar = $guzzleCookieJar;
+    }
+
     /**
      * @param Request $request
      *
@@ -96,13 +111,20 @@ class Client extends BaseClient
             }
         }
 
-        $cookies = CookieJar::fromArray(
-            $this->getCookieJar()->allRawValues($request->getUri()),
-            parse_url($request->getUri(), PHP_URL_HOST)
-        );
+        $cookies = $this->getCookieJar()->allRawValues($request->getUri());
+        $domain = parse_url($request->getUri(), PHP_URL_HOST);
+
+        foreach ($cookies as $name => $value) {
+            $this->getGuzzleCookieJar()->setCookie(new SetCookie([
+                'Domain'  => $domain,
+                'Name'    => $name,
+                'Value'   => $value,
+                'Discard' => true
+            ]));
+        }
 
         $requestOptions = array(
-            'cookies' => $cookies,
+            'cookies' => $this->getGuzzleCookieJar(),
             'allow_redirects' => false,
             'auth' => $this->auth,
         );

--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -83,6 +83,7 @@ class Client extends BaseClient
         if (empty($this->guzzleCookieJar)) {
             $this->guzzleCookieJar = new CookieJar();
         }
+
         return $this->guzzleCookieJar;
     }
 

--- a/Goutte/Tests/ClientTest.php
+++ b/Goutte/Tests/ClientTest.php
@@ -136,8 +136,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $jar = new SessionCookieJar('sessionVar', $testSaveSessionCookie);
         $client->setGuzzleCookieJar($jar);
 
-        $client->getCookieJar()->set(new Cookie('test', '123', null, '/', 'www.example.com'));
-        $client->getCookieJar()->set(new Cookie('foo', 'bar', time() + 1000, '/', 'www.example.com'));
+        $client->getCookieJar()->set(new Cookie('test', '123'));
+        $client->getCookieJar()->set(new Cookie('foo', 'bar', time() + 1000));
         $client->request('GET', 'http://www.example.com/');
 
         // Call to destruct method manually to test saving cookies
@@ -177,8 +177,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $jar = new FileCookieJar($filename, $testSaveSessionCookie);
         $client->setGuzzleCookieJar($jar);
 
-        $client->getCookieJar()->set(new Cookie('test', '123', null, '/', 'www.example.com'));
-        $client->getCookieJar()->set(new Cookie('foo', 'bar', time() + 1000, '/', 'www.example.com'));
+        $client->getCookieJar()->set(new Cookie('test', '123'));
+        $client->getCookieJar()->set(new Cookie('foo', 'bar', time() + 1000));
         $client->request('GET', 'http://www.example.com/');
 
         // Call to destruct method manually to test saving cookies

--- a/Goutte/Tests/ClientTest.php
+++ b/Goutte/Tests/ClientTest.php
@@ -163,7 +163,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(false),
-            array(true)
+            array(true),
         );
     }
 
@@ -203,7 +203,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(false),
-            array(true)
+            array(true),
         );
     }
 


### PR DESCRIPTION
When using the standard CookieJar the cookies only last the duration of the PHP script. When the PHP script terminates, the cookies will have been lost. To maintain the cookies across script executions, I updated Goutte to support FileCookieJar and SessionCookieJar.
