### PR TITLE
Allow caching responses...

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -33,6 +33,7 @@ class Client extends BaseClient
 
     private $headers = array();
     private $auth = null;
+    private $options = [];
 
     public function setClient(GuzzleClientInterface $client)
     {
@@ -43,11 +44,25 @@ class Client extends BaseClient
 
     public function getClient()
     {
+        $default_options = array('defaults' => array('allow_redirects' => false, 'cookies' => true));
+        $options = array_merge($default_options, $this->options);
+
         if (!$this->client) {
-            $this->client = new GuzzleClient(array('defaults' => array('allow_redirects' => false, 'cookies' => true)));
+            $this->client = new GuzzleClient($options);
         }
 
         return $this->client;
+    }
+
+    public function setOptions($options)
+    {
+        if (!is_array($options)) {
+            throw new \Exception('setOptions must be passed an array');
+        }
+
+        $this->options = options;
+
+        return $this;
     }
 
     public function setHeader($name, $value)

--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,43 @@ Submit forms:
         print $node->text()."\n";
     });
 
+Adding a cache to the crawler
+=============================
+
+By using a Guzzle handler such as .._`rtheunissen/guzzle-cache-handler`: https://github.com/rtheunissen/guzzle-cache-handler 
+you can cache responses very easily:
+
+.. code-block:: php
+
+    use Goutte\Client;
+    use Concat\Http\Handler\CacheHandler;
+    use Doctrine\Common\Cache\FilesystemCache;
+
+    // Basic directory cache example
+    $cacheProvider = new FilesystemCache(__DIR__ . '/cache');
+    $handler = new CacheHandler($cacheProvider, $defaultHandler, [
+        /**
+         * @var array HTTP methods that should be cached.
+         */
+        'methods' => ['GET'],
+
+        /**
+         * @var integer Time in seconds to cache a response for.
+         */
+        'expire' => 3600 /* one hour */,
+
+        /**
+         * @var callable Accepts a request and returns true if it should be cached.
+         */
+        'filter' => null,
+    ]);
+
+    $client = new Client();
+
+    $client->setOptions(
+        array('handler' => $handler)
+    )
+
 More Information
 ----------------
 


### PR DESCRIPTION
Added a new function, `setOptions` which allows setting options that will be passed into Guzzle's `Client`.

This enables using something like `rtheunissen/guzzle-cache-handler` to cache responses (also, you can add other middleware and change other Guzzle options, too!).
