### PR TITLE
Fix bug: tmp_name check

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -162,7 +162,7 @@ class Client extends BaseClient
             ];
 
             if (is_array($info)) {
-                if (isset($info['tmp_name'])) {
+                if (isset($info['tmp_name']) && !is_array($info['tmp_name'])) {
                     if ('' !== $info['tmp_name']) {
                         $file['contents'] = fopen($info['tmp_name'], 'r');
                         if (isset($info['name'])) {


### PR DESCRIPTION
The form names containing `tmp_name` may cause errors on `fopen()` call.

``` html
<form method="post" action="" enctype="multipart/form-data">
    <input type="submit">
    <input type="file" name="file[x][tmp_name][y]">
</form>
```

So we should check if `tmp_name` is not array using `!is_array()`.
