### PR TITLE
Fix tests after #246 was merged (header case normalization)

### DIFF
--- a/Goutte/Tests/ClientTest.php
+++ b/Goutte/Tests/ClientTest.php
@@ -380,7 +380,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $reflectionProperty = new \ReflectionProperty('Goutte\Client', 'headers');
         $reflectionProperty->setAccessible(true);
-        $this->assertEquals(array('X-Test' => 'test'), $reflectionProperty->getValue($client));
+        $this->assertEquals(array('x-test' => 'test'), $reflectionProperty->getValue($client));
 
         $client->resetHeaders();
         $this->assertEquals([], $reflectionProperty->getValue($client));
@@ -394,7 +394,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $headersReflectionProperty = new \ReflectionProperty('Goutte\Client', 'headers');
         $headersReflectionProperty->setAccessible(true);
-        $this->assertEquals(array('X-Test' => 'test'), $headersReflectionProperty->getValue($client));
+        $this->assertEquals(array('x-test' => 'test'), $headersReflectionProperty->getValue($client));
 
         $authReflectionProperty = new \ReflectionProperty('Goutte\Client', 'auth');
         $authReflectionProperty->setAccessible(true);


### PR DESCRIPTION
When #246 was merged (4471f18306f66cce4218db28d047afa27df65cfd), [tests started failing](https://travis-ci.org/FriendsOfPHP/Goutte/builds/176095879).  This pull requests adjusts the assert header case to fix the failed tests.

```
There were 2 failures:
1) Goutte\Tests\ClientTest::testResetHeaders
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    'X-Test' => 'test'
+    'x-test' => 'test'
 )
/home/travis/build/FriendsOfPHP/Goutte/Goutte/Tests/ClientTest.php:383
2) Goutte\Tests\ClientTest::testRestart
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    'X-Test' => 'test'
+    'x-test' => 'test'
 )
/home/travis/build/FriendsOfPHP/Goutte/Goutte/Tests/ClientTest.php:397
```