### PR TITLE
Add GET parameters to Guzzle request

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -137,6 +137,8 @@ class Client extends BaseClient
                     $requestOptions['form_params'] = $request->getParameters();
                 }
             }
+        } else {
+            $requestOptions['query'] = $request->getParameters();
         }
 
         if (!empty($headers)) {

--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -129,7 +129,7 @@ class Client extends BaseClient
                 $requestOptions['body'] = $content;
             } else {
                 if ($files = $request->getFiles()) {
-                    $requestOptions['multipart'] = array();
+                    $requestOptions['multipart'] = [];
 
                     $this->addPostFields($request->getParameters(), $requestOptions['multipart']);
                     $this->addPostFiles($files, $requestOptions['multipart']);
@@ -176,9 +176,9 @@ class Client extends BaseClient
                 $name = $arrayName.'['.$name.']';
             }
 
-            $file = array(
+            $file = [
                 'name' => $name,
-            );
+            ];
 
             if (is_array($info)) {
                 if (isset($info['tmp_name'])) {
@@ -212,10 +212,10 @@ class Client extends BaseClient
             if (is_array($value)) {
                 $this->addPostFields($value, $multipart, $name);
             } else {
-                $multipart[] = array(
+                $multipart[] = [
                     'name' => $name,
                     'contents' => $value,
-                );
+                ];
             }
         }
     }

--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -129,7 +129,7 @@ class Client extends BaseClient
                 $requestOptions['body'] = $content;
             } else {
                 if ($files = $request->getFiles()) {
-                    $requestOptions['multipart'] = [];
+                    $requestOptions['multipart'] = array();
 
                     $this->addPostFields($request->getParameters(), $requestOptions['multipart']);
                     $this->addPostFiles($files, $requestOptions['multipart']);
@@ -176,9 +176,9 @@ class Client extends BaseClient
                 $name = $arrayName.'['.$name.']';
             }
 
-            $file = [
+            $file = array(
                 'name' => $name,
-            ];
+            );
 
             if (is_array($info)) {
                 if (isset($info['tmp_name'])) {
@@ -212,10 +212,10 @@ class Client extends BaseClient
             if (is_array($value)) {
                 $this->addPostFields($value, $multipart, $name);
             } else {
-                $multipart[] = [
+                $multipart[] = array(
                     'name' => $name,
                     'contents' => $value,
-                ];
+                );
             }
         }
     }


### PR DESCRIPTION
GET parameters are not passed down to Guzzle client. They are only passed in config when creating the client but if you want to reuse the client for multiple request, there is no way to pass new parameters for each new request.