### PR TITLE
Fix the example in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Make requests with the ``request()`` method:
 .. code-block:: php
 
     // Go to the symfony.com website
-    $crawler = $client->request('GET', 'https://www.symfony.com/blog/');
+    $crawler = $client->request('GET', 'https://symfony.com/blog/');
 
 The method returns a ``Crawler`` object
 (``Symfony\Component\DomCrawler\Crawler``).


### PR DESCRIPTION
The URL https://www.symfony.com/blog/ has an invalid SSL certificate, so the example fail:

```
PHP Fatal error:  Uncaught Guzzle\Http\Exception\CurlException: [curl] 51: SSL: no alternative certificate subject name matches target host name 'www.symfony.com' [url] https://www.symfony.com/blog/ in phar:///Users/dunglas/workspace/bytel/test-machine/goutte-v1.0.7.phar/vendor/guzzle/http/Guzzle/Http/Curl/CurlMulti.php:359
```

A better fix would be to fix the certificate on www.symfony.com 🙃