### PR TITLE
Allow http exceptions

### DIFF
--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -176,14 +176,7 @@ class Client extends BaseClient
         }
 
         // Let BrowserKit handle redirects
-        try {
-            $response = $this->getClient()->request($method, $uri, $requestOptions);
-        } catch (RequestException $e) {
-            $response = $e->getResponse();
-            if (null === $response) {
-                throw $e;
-            }
-        }
+        $response = $this->getClient()->request($method, $uri, $requestOptions);
 
         return $this->createResponse($response);
     }


### PR DESCRIPTION
Fixes #355 

Let users decide if they want http exceptions with the `http_errors` guzzle option.