### PR TITLE
Remove PHP5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,9 @@ env:
         - SYMFONY_PHPUNIT_DIR=$HOME/.phpunit_bridge
 
 php:
+    - 7.3
     - 7.2
     - 7.1
-    - 7.0
-    - 5.6
-    - 5.5
-    - nightly
 
 install:
     - composer update

--- a/README.rst
+++ b/README.rst
@@ -9,9 +9,12 @@ responses.
 Requirements
 ------------
 
-Goutte depends on PHP 5.5+ and Guzzle 6+.
+Goutte depends on PHP 7.1+ and Guzzle 6+.
 
 .. tip::
+
+    If you need support for PHP 5.5, use Goutte 3.x (latest `phar
+    <https://github.com/FriendsOfPHP/Goutte/releases/download/v3.1.0/goutte-v3.1.0.phar>`_).
 
     If you need support for PHP 5.4 or Guzzle 4-5, use Goutte 2.x (latest `phar
     <https://github.com/FriendsOfPHP/Goutte/releases/download/v2.0.4/goutte-v2.0.4.phar>`_).

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
-        "symfony/browser-kit": "~2.1|~3.0|~4.0",
-        "symfony/css-selector": "~2.1|~3.0|~4.0",
-        "symfony/dom-crawler": "~2.1|~3.0|~4.0",
+        "php": "^7.1.3",
+        "symfony/browser-kit": "~3.4|~4.0",
+        "symfony/css-selector": "~3.4|~4.0",
+        "symfony/dom-crawler": "~3.4|~4.0",
         "guzzlehttp/guzzle": "^6.0"
     },
     "require-dev": {
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.2-dev"
+            "dev-master": "4.0-dev"
         }
     }
 }


### PR DESCRIPTION
As requested there : https://github.com/FriendsOfPHP/Goutte/pull/382#discussion_r298563682

But i'm not sure that we actually want to drop the support for Symfony 2.8... Should we wait for EOL ? Or is there another way ?