### PR TITLE
Allow php8 on v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
         - SYMFONY_PHPUNIT_DIR=$HOME/.phpunit_bridge
 
 php:
+    - nightly
     - 7.4
     - 7.3
     - 7.2

--- a/Goutte/Client.php
+++ b/Goutte/Client.php
@@ -21,8 +21,6 @@ use Symfony\Component\BrowserKit\Request;
 use Symfony\Component\BrowserKit\Response;
 
 /**
- * Client.
- *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Michael Dowling <michael@guzzlephp.org>
  * @author Charles Sarrazin <charles@sarraz.in>

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.1-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.1.3 || ^8.0",
         "symfony/browser-kit": "^4.4|^5.0",
         "symfony/css-selector": "^4.4|^5.0",
         "symfony/dom-crawler": "^4.4|^5.0",


### PR DESCRIPTION
Can commit f117817 be cherry-picked on top of 3.3.0 and a new release made. It would really help Drupal to have a v3 of Goutte that is PHP 8 compatible. We've got a plan to move off Goutte v3 but it would really help if we could do that in Drupal 10 and not mid Drupal 9 cycle.